### PR TITLE
Add Azure SignalR to improve resiliency

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,7 @@
     <PackageVersion Include="Ardalis.Result" Version="4.1.0" />
     <PackageVersion Include="Ardalis.Specification" Version="6.1.0" />
     <PackageVersion Include="MediatR" Version="11.1.0" />
+    <PackageVersion Include="Microsoft.Azure.SignalR" Version="1.21.2" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="7.0.1" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.1" />

--- a/src/RollOfHonour.Web/Program.cs
+++ b/src/RollOfHonour.Web/Program.cs
@@ -27,6 +27,11 @@ builder.Services.AddMicrosoftIdentityWebAppAuthentication(builder.Configuration,
 builder.Services.AddRazorPages()
     .AddMicrosoftIdentityUI();
 
+builder.Services.AddSignalR().AddAzureSignalR(options =>
+{
+    options.ServerStickyMode = Microsoft.Azure.SignalR.ServerStickyMode.Required;
+});
+
 builder.Services.AddServerSideBlazor();
 
 var app = builder.Build();

--- a/src/RollOfHonour.Web/RollOfHonour.Web.csproj
+++ b/src/RollOfHonour.Web/RollOfHonour.Web.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" />
+    <PackageReference Include="Microsoft.Azure.SignalR" />
     <PackageReference Include="Microsoft.Identity.Web" />
     <PackageReference Include="Microsoft.Identity.Web.UI" />
   </ItemGroup>


### PR DESCRIPTION
Recommended by Microsoft to use Azure SignalR when deployed to Azure.