### PR TITLE
Show real images on Memorial Details page

### DIFF
--- a/src/RollOfHonour.Web/Pages/Memorial/Details.cshtml
+++ b/src/RollOfHonour.Web/Pages/Memorial/Details.cshtml
@@ -134,66 +134,24 @@
 
                 <div class="gallery-block">
                     <div class="columns is-multiline">
-                        <div class="column is-4-desktop">
-                            <a href="/images/sample-data/memorial-image1.jpeg" title="Portrait of Reginald Dudley Bawdwen Anderson. Courtesy of Worksop College">
-                                <div class="picture-block short styled-alt">
-                                    <div class="picture-border">
-                                        <div
-                                            class="picture-embed"
-                                            style="
-												background-image: url(/images/sample-data/memorial-image1.jpeg);
+                        
+                        @foreach (var photo in Model.Memorial.Photos)
+                        {
+                            <div class="column is-4-desktop">
+                                <a href="@photo.ImageUriMedium" title="Portrait of Reginald Dudley Bawdwen Anderson. Courtesy of Worksop College">
+                                    <div class="picture-block short styled-alt">
+                                        <div class="picture-border">
+                                            <div
+                                                class="picture-embed"
+                                                style="
+												background-image: url(@photo.ImageUriOriginal);
 											  ">
+                                            </div>
                                         </div>
                                     </div>
-                                </div>
-                            </a>
-                        </div>
-
-                        <div class="column is-4-desktop">
-                            <a href="/images/sample-data/memorial-image2.jpeg" title="Photo of Reginald Dudley Bawdwen Anderson ">
-                                <div class="picture-block short styled">
-                                    <div class="picture-border">
-                                        <div
-                                            class="picture-embed"
-                                            style="
-												background-image: url(/images/sample-data/memorial-image2.jpeg);
-											  ">
-                                        </div>
-                                    </div>
-                                </div>
-                            </a>
-                        </div>
-
-                        <div class="column is-4-desktop">
-                            <a href="/images/sample-data/memorial-image3.jpeg" title="Commonwealth War Graves Commission headstone marking the grave of Reginald Dudley Bawden Anderson at Redan Ridge Cemetery no 2 Courtesy of Peter Gillings">
-                                <div class="picture-block short styled">
-                                    <div class="picture-border">
-                                        <div
-                                            class="picture-embed"
-                                            style="
-												background-image: url(/images/sample-data/memorial-image3.jpeg);
-											  ">
-                                        </div>
-                                    </div>
-                                </div>
-                            </a>
-                        </div>
-
-                        <div class="column is-4-desktop">
-                            <a href="/images/sample-data/memorial-image4.jpeg" title="Commonwealth War Graves Commission headstone marking the grave of Reginald Dudley Bawden Anderson at Redan Ridge Cemetery no 2 Courtesy of Peter Gillings">
-                                <div class="picture-block short styled">
-                                    <div class="picture-border">
-                                        <div
-                                            class="picture-embed"
-                                            style="
-												background-image: url(/images/sample-data/memorial-image4.jpeg);
-											  ">
-                                        </div>
-                                    </div>
-                                </div>
-                            </a>
-                        </div>
-
+                                </a>
+                            </div>
+                        }
                     </div>
                 </div>
 
@@ -208,7 +166,7 @@
         <aside class="sidebar">
             <div class="picture-block memorial-picture">
                 <div class="picture-border">
-                    <div class="picture-embed" style="background-image: url(/images/sample-data/memorial-image1.jpeg);"></div>
+                    <div class="picture-embed" style="background-image: url(@Model.Memorial.MainPhoto?.ImageUriMedium);"></div>
                 </div>
             </div>
 


### PR DESCRIPTION
Previously fixed sample/test images were showing on the Memorial Details page.  
Now the appropriate images are shown on for the main image.  Also the photographs tab show all photos for a monument.