### PR TITLE
Implement regiment filtering

### DIFF
--- a/src/RollOfHonour.Core/Models/Person.cs
+++ b/src/RollOfHonour.Core/Models/Person.cs
@@ -20,7 +20,9 @@ public class Person
   public string ServiceNumber { get; set; } = string.Empty;
 
   public string Unit { get; set; } = string.Empty;
+  public int? UnitId { get; set; }
   public string Regiment { get; set; } = string.Empty;
+  public int? RegimentId { get; set; }
 
   public string UnitRegimentString
   {

--- a/src/RollOfHonour.Core/Models/Search/Filters.cs
+++ b/src/RollOfHonour.Core/Models/Search/Filters.cs
@@ -6,14 +6,14 @@ public class Filters
     public DateTime DiedBefore { get; }
     public DateTime BornAfter { get; }
     public PersonType SelectedPersonType { get; }
-    public List<int> Regiments { get; }
+    public HashSet<int> Regiments { get; }
 
     public bool DateRangeUsed => DiedBefore.Year != 1900 || BornAfter.Year != 1900;
     public bool HasRegiments => Regiments.Count() != 0;
 
     public bool IsFiltered => HasRegiments || DateRangeUsed;
 
-    public Filters(int diedBefore, int bornAfter, PersonType personType, List<int> regiments)
+    public Filters(int diedBefore, int bornAfter, PersonType personType, HashSet<int> regiments)
     {
         DiedBefore = new DateTime(diedBefore, 1, 1);
         BornAfter = new DateTime(bornAfter, 1, 1);

--- a/src/RollOfHonour.Core/Models/Search/RegimentFilter.cs
+++ b/src/RollOfHonour.Core/Models/Search/RegimentFilter.cs
@@ -2,10 +2,10 @@ namespace RollOfHonour.Core.Models.Search;
 
 public class RegimentFilter
 {
-    public string Regiment { get; set; } = string.Empty;
+    public string Regiment { get; set; } 
     public int RegimentId { get; set; }
 
-    public RegimentFilter(int regimentId, string regiment )
+    public RegimentFilter(int regimentId, string regiment)
     {
         RegimentId = regimentId;
         Regiment = regiment;

--- a/src/RollOfHonour.Core/Models/Search/RegimentFilter.cs
+++ b/src/RollOfHonour.Core/Models/Search/RegimentFilter.cs
@@ -1,0 +1,13 @@
+namespace RollOfHonour.Core.Models.Search;
+
+public class RegimentFilter
+{
+    public string Regiment { get; set; } = string.Empty;
+    public int RegimentId { get; set; }
+
+    public RegimentFilter(int regimentId, string regiment )
+    {
+        RegimentId = regimentId;
+        Regiment = regiment;
+    }
+}

--- a/src/RollOfHonour.Core/Search/ISuperSearchService.cs
+++ b/src/RollOfHonour.Core/Search/ISuperSearchService.cs
@@ -8,4 +8,5 @@ public interface ISuperSearchService
 {
   Task<Result<PaginatedList<Core.Models.Person>>> PersonSearch(PersonQuery searchQuery, Filters filters, int pageNumber, int pageSize);
   Task<Result<PaginatedList<Core.Models.Memorial>>> MemorialSearch(MemorialQuery searchQuery, int pageNumber, int pageSize);
+  Task<List<RegimentFilter>> GetRegimentFiltersForSearch(PersonQuery query);
 }

--- a/src/RollOfHonour.Core/Search/SuperSearchService.cs
+++ b/src/RollOfHonour.Core/Search/SuperSearchService.cs
@@ -16,6 +16,11 @@ public class SuperSearchService : ISuperSearchService
         _memorialRepository = memorialRepository;
     }
 
+    public async Task<List<RegimentFilter>> GetRegimentFiltersForSearch(PersonQuery query)
+    {
+        return await _personRepository.GetRegimentFiltersForSearch(query);
+    }
+
     public async Task<Result<PaginatedList<Core.Models.Memorial>>> MemorialSearch(MemorialQuery query, int pageNumber, int pageSize)
     {
         if (string.IsNullOrEmpty(query.SearchTerm))

--- a/src/RollOfHonour.Core/Shared/IPersonRepository.cs
+++ b/src/RollOfHonour.Core/Shared/IPersonRepository.cs
@@ -11,4 +11,5 @@ public interface IPersonRepository
     int Count();
     Task<PaginatedList<Core.Models.Person>> SearchPeople(PersonQuery query, Filters filters, int pageIndex, int pageSize);
     Task<PaginatedList<Person>> GetPageOfPeople(int pageIndex, int pageSize);
+    Task<List<RegimentFilter>> GetRegimentFiltersForSearch(PersonQuery query);
 }

--- a/src/RollOfHonour.Core/Shared/IPersonRepository.cs
+++ b/src/RollOfHonour.Core/Shared/IPersonRepository.cs
@@ -6,7 +6,6 @@ namespace RollOfHonour.Core.Shared;
 public interface IPersonRepository
 {
     Task<Person?> GetById(int id);
-    Task<IEnumerable<Person>> GetAll();
     Task<IEnumerable<Person>> DiedOnThisDay(DateTime date);
     int Count();
     Task<PaginatedList<Core.Models.Person>> SearchPeople(PersonQuery query, Filters filters, int pageIndex, int pageSize);

--- a/src/RollOfHonour.Data/Models/DB/Person.cs
+++ b/src/RollOfHonour.Data/Models/DB/Person.cs
@@ -2,111 +2,113 @@
 
 public class Person
 {
-  public Core.Models.Person ToDomainModel(string blobServiceName, string blobImagesContainer)
-  {
-    var person = new Core.Models.Person(this.MainPhotoId)
+    public Core.Models.Person ToDomainModel(string blobServiceName, string blobImagesContainer)
     {
-      Id = this.Id,
-      Comments = this.Comments,
-      Cwgc = this.Cwgc,
-      Deleted = this.Deleted,
-      Initials = this.Initials ?? string.Empty,
-      Rank = this.Rank ?? string.Empty,
-      EmploymentHobbies = this.EmploymentHobbies,
-      ExtraInfo = this.ExtraInfo,
-      FamilyHistory = this.FamilyHistory,
-      FirstNames = this.FirstNames ?? string.Empty,
-      LastName = this.LastName ?? string.Empty,
-      MilitaryHistory = this.MilitaryHistory,
-      ServiceNumber = this.ServiceNumber ?? string.Empty,
-      AddressAtEnlistment = this.AddressAtEnlistment,
-      AgeAtDeath = this.AgeAtDeath,
-      DateOfBirth = this.DateOfBirth,
-      DateOfDeath = this.DateOfDeath,
-      PlaceOfBirth = this.PlaceOfBirth,
-      Unit = this.SubUnit?.Name == null ? string.Empty : this.SubUnit.Name,
-      Regiment = this.SubUnit?.Regiment?.Name == null ? string.Empty : this.SubUnit.Regiment.Name
-    };
+        var person = new Core.Models.Person(this.MainPhotoId)
+        {
+            Id = this.Id,
+            Comments = this.Comments,
+            Cwgc = this.Cwgc,
+            Deleted = this.Deleted,
+            Initials = this.Initials ?? string.Empty,
+            Rank = this.Rank ?? string.Empty,
+            EmploymentHobbies = this.EmploymentHobbies,
+            ExtraInfo = this.ExtraInfo,
+            FamilyHistory = this.FamilyHistory,
+            FirstNames = this.FirstNames ?? string.Empty,
+            LastName = this.LastName ?? string.Empty,
+            MilitaryHistory = this.MilitaryHistory,
+            ServiceNumber = this.ServiceNumber ?? string.Empty,
+            AddressAtEnlistment = this.AddressAtEnlistment,
+            AgeAtDeath = this.AgeAtDeath,
+            DateOfBirth = this.DateOfBirth,
+            DateOfDeath = this.DateOfDeath,
+            PlaceOfBirth = this.PlaceOfBirth,
+            Unit = this.SubUnit?.Name == null ? string.Empty : this.SubUnit.Name,
+            UnitId = this.SubUnitId == null ? null : this.SubUnitId,
+            Regiment = this.SubUnit?.Regiment?.Name == null ? string.Empty : this.SubUnit.Regiment.Name,
+            RegimentId = this.SubUnit?.RegimentId
+        };
 
-    foreach (var decoration in this.Decorations)
-    {
-      person.Decorations.Add(decoration.ToDomainModel());
+        foreach (var decoration in this.Decorations)
+        {
+            person.Decorations.Add(decoration.ToDomainModel());
+        }
+
+        foreach (var memorial in this.RecordedNames.Select(rn => rn.WarMemorial).Distinct())
+        {
+            person.Memorials.Add(memorial.Id, memorial.Name);
+        }
+
+        foreach (var photo in this.Photos)
+        {
+            person.Photos.Add(photo.ToDomainModel(blobServiceName, blobImagesContainer));
+        }
+
+        return person;
     }
 
-    foreach (var memorial in this.RecordedNames.Select(rn => rn.WarMemorial).Distinct())
-    {
-      person.Memorials.Add(memorial.Id, memorial.Name);
-    }
+    public int Id { get; set; }
 
-    foreach (var photo in this.Photos)
-    {
-      person.Photos.Add(photo.ToDomainModel(blobServiceName, blobImagesContainer));
-    }
+    public string? FirstNames { get; set; }
 
-    return person;
-  }
+    public string? Initials { get; set; }
 
-  public int Id { get; set; }
+    public string? LastName { get; set; }
 
-  public string? FirstNames { get; set; }
+    public string? Rank { get; set; }
 
-  public string? Initials { get; set; }
+    public string? ServiceNumber { get; set; }
 
-  public string? LastName { get; set; }
+    public DateTime? DateOfBirth { get; set; }
 
-  public string? Rank { get; set; }
+    public DateTime? DateOfDeath { get; set; }
 
-  public string? ServiceNumber { get; set; }
+    public int? AgeAtDeath { get; set; }
 
-  public DateTime? DateOfBirth { get; set; }
+    public string? Comments { get; set; }
 
-  public DateTime? DateOfDeath { get; set; }
+    public int? MainPhotoId { get; set; }
 
-  public int? AgeAtDeath { get; set; }
+    public int? SubUnitId { get; set; }
 
-  public string? Comments { get; set; }
+    public int? WarId { get; set; }
 
-  public int? MainPhotoId { get; set; }
+    public int? ArmedServiceId { get; set; }
 
-  public int? SubUnitId { get; set; }
+    public bool Deleted { get; set; }
 
-  public int? WarId { get; set; }
+    public string? AddressAtEnlistment { get; set; }
 
-  public int? ArmedServiceId { get; set; }
+    public int? Cwgc { get; set; }
 
-  public bool Deleted { get; set; }
+    public string? PlaceOfBirth { get; set; }
 
-  public string? AddressAtEnlistment { get; set; }
+    public string? EmploymentHobbies { get; set; }
 
-  public int? Cwgc { get; set; }
+    public string? FamilyHistory { get; set; }
 
-  public string? PlaceOfBirth { get; set; }
+    public string? MilitaryHistory { get; set; }
 
-  public string? EmploymentHobbies { get; set; }
+    public string? ExtraInfo { get; set; }
 
-  public string? FamilyHistory { get; set; }
+    public virtual ArmedService? ArmedService { get; set; }
 
-  public string? MilitaryHistory { get; set; }
+    public virtual Photo? MainPhoto { get; set; }
 
-  public string? ExtraInfo { get; set; }
+    public virtual ICollection<PersonAuditItem> PersonAuditItems { get; } = new List<PersonAuditItem>();
 
-  public virtual ArmedService? ArmedService { get; set; }
+    public virtual ICollection<PersonModeration> PersonModerations { get; } = new List<PersonModeration>();
 
-  public virtual Photo? MainPhoto { get; set; }
+    public virtual ICollection<PhotoModeration> PhotoModerations { get; } = new List<PhotoModeration>();
 
-  public virtual ICollection<PersonAuditItem> PersonAuditItems { get; } = new List<PersonAuditItem>();
+    public virtual ICollection<Photo> Photos { get; } = new List<Photo>();
 
-  public virtual ICollection<PersonModeration> PersonModerations { get; } = new List<PersonModeration>();
+    public virtual ICollection<RecordedName> RecordedNames { get; } = new List<RecordedName>();
 
-  public virtual ICollection<PhotoModeration> PhotoModerations { get; } = new List<PhotoModeration>();
+    public virtual SubUnit? SubUnit { get; set; }
 
-  public virtual ICollection<Photo> Photos { get; } = new List<Photo>();
+    public virtual War? War { get; set; }
 
-  public virtual ICollection<RecordedName> RecordedNames { get; } = new List<RecordedName>();
-
-  public virtual SubUnit? SubUnit { get; set; }
-
-  public virtual War? War { get; set; }
-
-  public virtual ICollection<Decoration> Decorations { get; } = new List<Decoration>();
+    public virtual ICollection<Decoration> Decorations { get; } = new List<Decoration>();
 }

--- a/src/RollOfHonour.Data/Repositories/MemorialRepository.cs
+++ b/src/RollOfHonour.Data/Repositories/MemorialRepository.cs
@@ -75,8 +75,7 @@ public class MemorialRepository : IMemorialRepository
 
         if (resultCount == 0)
         {
-            //TODO: handle case where there are none
-            throw new NotImplementedException();
+            return new PaginatedList<Memorial>();
         }
 
         dbMemorials = dbMemorials.Skip(

--- a/src/RollOfHonour.Data/Repositories/PersonRepository.cs
+++ b/src/RollOfHonour.Data/Repositories/PersonRepository.cs
@@ -43,24 +43,6 @@ public class PersonRepository : IPersonRepository
         }
     }
 
-    // TODO: Should this return a null rather than an empty enumerable?
-    public async Task<IEnumerable<Person>> GetAll()
-    {
-        try
-        {
-            var people = await _dbContext.People
-              .Include(p => p.Photos)
-              //.Take(25)
-              .ToListAsync();
-
-            return people.Select(p => p.ToDomainModel(settingBlobName, settingBlobImageContainerName));
-        }
-        catch (Exception)
-        {
-            return Enumerable.Empty<Person>();
-        }
-    }
-
     public async Task<IEnumerable<Person>> DiedOnThisDay(DateTime date)
     {
         var countOfPeople = _dbContext.People.Count();

--- a/src/RollOfHonour.Data/Repositories/PersonRepository.cs
+++ b/src/RollOfHonour.Data/Repositories/PersonRepository.cs
@@ -78,14 +78,6 @@ public class PersonRepository : IPersonRepository
         {
             dbPeople = FilterPeople(dbPeople, filters);
         }
-        else
-        {
-            var regiments = dbPeople
-                .Where(p => p.SubUnit != null && p.SubUnit.RegimentId.HasValue && p.SubUnit.Regiment != null && !string.IsNullOrEmpty(p.SubUnit.Regiment.Name))
-                .Select(p => new RegimentFilter((int)p.SubUnit!.RegimentId!, p.SubUnit!.Regiment!.Name!))
-                .Distinct()
-                .ToList();
-        }
 
         var resultCount = dbPeople.Count();
         if (resultCount == 0)

--- a/src/RollOfHonour.Data/Repositories/PersonRepository.cs
+++ b/src/RollOfHonour.Data/Repositories/PersonRepository.cs
@@ -99,8 +99,7 @@ public class PersonRepository : IPersonRepository
         var resultCount = dbPeople.Count();
         if (resultCount == 0)
         {
-            // return something else
-            throw new NotImplementedException();
+            return new PaginatedList<Person>();
         }
 
         dbPeople = dbPeople
@@ -144,7 +143,17 @@ public class PersonRepository : IPersonRepository
             people = BornAfter(people, filters.BornAfter);
         }
 
+        if (filters.HasRegiments)
+        {
+            people = ByRegiment(people, filters.Regiments);
+        }
+
         return people;
+    }
+
+    private IQueryable<Models.DB.Person> ByRegiment(IQueryable<Models.DB.Person> people, HashSet<int> regimentIds)
+    {
+        return people.Where(p => p.SubUnit != null && p.SubUnit.RegimentId.HasValue && regimentIds.Contains((int)p.SubUnit.RegimentId));
     }
 
     private IQueryable<Models.DB.Person> DiedBefore(IQueryable<Models.DB.Person> people, DateTime date)

--- a/src/RollOfHonour.Data/Repositories/PersonRepository.cs
+++ b/src/RollOfHonour.Data/Repositories/PersonRepository.cs
@@ -127,6 +127,7 @@ public class PersonRepository : IPersonRepository
         var regiments = await dbPeople
             .Where(p => p.SubUnit != null && p.SubUnit.RegimentId.HasValue && p.SubUnit.Regiment != null && !string.IsNullOrEmpty(p.SubUnit.Regiment.Name))
             .Select(p => new RegimentFilter((int)p.SubUnit!.RegimentId!, p.SubUnit!.Regiment!.Name!))
+            .AsNoTracking()
             .Distinct()
             .ToListAsync();
 
@@ -139,6 +140,7 @@ public class PersonRepository : IPersonRepository
             .Include(p => p.Photos)
             .Skip((pageIndex - 1) * pageSize)
             .Take(pageSize)
+            .AsNoTracking()
             .ToListAsync();
 
         if (!dbPeople.Any())

--- a/src/RollOfHonour.Data/Repositories/PersonRepository.cs
+++ b/src/RollOfHonour.Data/Repositories/PersonRepository.cs
@@ -1,4 +1,4 @@
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 using RollOfHonour.Core.Search;
 using RollOfHonour.Core.Models;
 using RollOfHonour.Core.Models.Search;
@@ -132,7 +132,6 @@ public class PersonRepository : IPersonRepository
 
         return regiments;
     }
-
 
     public async Task<PaginatedList<Person>> GetPageOfPeople(int pageIndex, int pageSize)
     {

--- a/src/RollOfHonour.Data/Repositories/PersonRepository.cs
+++ b/src/RollOfHonour.Data/Repositories/PersonRepository.cs
@@ -9,57 +9,57 @@ namespace RollOfHonour.Data.Repositories;
 
 public class PersonRepository : IPersonRepository
 {
-  private string settingBlobName = "ncc01sarollhonstdlrsdev";
-  private string settingBlobImageContainerName = "images";
+    private string settingBlobName = "ncc01sarollhonstdlrsdev";
+    private string settingBlobImageContainerName = "images";
 
-  private RollOfHonourContext _dbContext { get; set; }
+    private RollOfHonourContext _dbContext { get; set; }
 
-  public PersonRepository(RollOfHonourContext dbContext)
-  {
-    _dbContext = dbContext;
-  }
-
-  public async Task<Person?> GetById(int id)
-  {
-    try
+    public PersonRepository(RollOfHonourContext dbContext)
     {
-      var dbPerson = await _dbContext.People
-        .Include(p => p.Photos)
-        .Include(p => p.Decorations)
-        .Include(p => p.RecordedNames).ThenInclude(rn => rn.WarMemorial)
-        .Include(p => p.SubUnit).ThenInclude(unit => unit.Regiment)
-        .FirstOrDefaultAsync(p => p.Id == id);
+        _dbContext = dbContext;
+    }
 
-        if (dbPerson is null)
+    public async Task<Person?> GetById(int id)
+    {
+        try
+        {
+            var dbPerson = await _dbContext.People
+              .Include(p => p.Photos)
+              .Include(p => p.Decorations)
+              .Include(p => p.RecordedNames).ThenInclude(rn => rn.WarMemorial)
+              .Include(p => p.SubUnit).ThenInclude(unit => unit.Regiment)
+              .FirstOrDefaultAsync(p => p.Id == id);
+
+            if (dbPerson is null)
             {
                 // TODO: Is this necessary?
                 return null;
             }
-      return dbPerson.ToDomainModel(settingBlobName, settingBlobImageContainerName);
+            return dbPerson.ToDomainModel(settingBlobName, settingBlobImageContainerName);
+        }
+        catch (InvalidOperationException)
+        {
+            return null;
+        }
     }
-    catch (InvalidOperationException ex)
-    {
-      return null;
-    }
-  }
 
-  // TODO: Should this return a null rather than an empty enumerable?
-  public async Task<IEnumerable<Person>> GetAll()
-  {
-    try
+    // TODO: Should this return a null rather than an empty enumerable?
+    public async Task<IEnumerable<Person>> GetAll()
     {
-      var people = await _dbContext.People
-        .Include(p => p.Photos)
-        //.Take(25)
-        .ToListAsync();
+        try
+        {
+            var people = await _dbContext.People
+              .Include(p => p.Photos)
+              //.Take(25)
+              .ToListAsync();
 
-      return people.Select(p => p.ToDomainModel(settingBlobName, settingBlobImageContainerName));
+            return people.Select(p => p.ToDomainModel(settingBlobName, settingBlobImageContainerName));
+        }
+        catch (Exception)
+        {
+            return Enumerable.Empty<Person>();
+        }
     }
-    catch (Exception)
-    {
-        return Enumerable.Empty<Person>();
-    }
-  }
 
     public async Task<IEnumerable<Person>> DiedOnThisDay(DateTime date)
     {
@@ -90,10 +90,19 @@ public class PersonRepository : IPersonRepository
 
     public async Task<PaginatedList<Person>> SearchPeople(PersonQuery query, Filters filters, int pageIndex, int pageSize)
     {
-        var dbPeople = GetPeopleByName(query, pageIndex, pageSize);
+        var dbPeople = GetPeopleByName(query);
+
         if (filters.IsFiltered)
         {
             dbPeople = FilterPeople(dbPeople, filters);
+        }
+        else
+        {
+            var regiments = dbPeople
+                .Where(p => p.SubUnit != null && p.SubUnit.RegimentId.HasValue && p.SubUnit.Regiment != null && !string.IsNullOrEmpty(p.SubUnit.Regiment.Name))
+                .Select(p => new RegimentFilter((int)p.SubUnit!.RegimentId!, p.SubUnit!.Regiment!.Name!))
+                .Distinct()
+                .ToList();
         }
 
         var resultCount = dbPeople.Count();
@@ -109,9 +118,21 @@ public class PersonRepository : IPersonRepository
             .AsNoTracking();
 
         var results = await dbPeople.Select(p => p.ToDomainModel(settingBlobName, settingBlobImageContainerName)).ToListAsync();
-        var paginatedResults = new PaginatedList<Person>(results, resultCount, pageIndex, pageSize);
-        return paginatedResults;
+        return new PaginatedList<Person>(results, resultCount, pageIndex, pageSize);
     }
+
+    public async Task<List<RegimentFilter>> GetRegimentFiltersForSearch(PersonQuery query)
+    {
+        var dbPeople = GetPeopleByName(query);
+        var regiments = await dbPeople
+            .Where(p => p.SubUnit != null && p.SubUnit.RegimentId.HasValue && p.SubUnit.Regiment != null && !string.IsNullOrEmpty(p.SubUnit.Regiment.Name))
+            .Select(p => new RegimentFilter((int)p.SubUnit!.RegimentId!, p.SubUnit!.Regiment!.Name!))
+            .Distinct()
+            .ToListAsync();
+
+        return regiments;
+    }
+
 
     public async Task<PaginatedList<Person>> GetPageOfPeople(int pageIndex, int pageSize)
     {
@@ -161,12 +182,12 @@ public class PersonRepository : IPersonRepository
         return people.Where(p => p.DateOfDeath <= date);
     }
 
-    private IQueryable<Models.DB.Person> BornAfter( IQueryable<Models.DB.Person> people, DateTime date)
+    private IQueryable<Models.DB.Person> BornAfter(IQueryable<Models.DB.Person> people, DateTime date)
     {
         return people.Where(p => p.DateOfBirth >= date);
     }
 
-    private IQueryable<Models.DB.Person> GetPeopleByName(PersonQuery query, int pageIndex, int pageSize)
+    private IQueryable<Models.DB.Person> GetPeopleByName(PersonQuery query)
     {
 
         var dbPeople = _dbContext.People
@@ -176,8 +197,8 @@ public class PersonRepository : IPersonRepository
               .ThenInclude(rn => rn.WarMemorial)
               .Include(p => p.SubUnit)
               .ThenInclude(unit => unit.Regiment)
-              .Where(p => p.FirstNames.Contains(query.SearchTerm)
-                || p.LastName.Contains(query.SearchTerm));
+              .Where(p => p.Deleted == false && (p.FirstNames.Contains(query.SearchTerm)
+                || p.LastName.Contains(query.SearchTerm)));
 
         return dbPeople;
     }

--- a/src/RollOfHonour.Web/Pages/Search/RegimentFilters.razor
+++ b/src/RollOfHonour.Web/Pages/Search/RegimentFilters.razor
@@ -1,0 +1,35 @@
+@using RollOfHonour.Core.Models.Search;
+
+<div class="search-filter-block">
+    <span class="filter-label">
+        Filter by regiment
+    </span>
+    <ul class="button-list">
+        @foreach (var regiment in Regiments)
+        {
+            <li>
+                <div class="button_checkbox">
+                    <input type="checkbox" @onchange="(e => UpdateRegiment(regiment.RegimentId))" id="@regiment.Regiment">
+                    <label for="@regiment.Regiment">@regiment.Regiment</label>
+                </div>
+            </li>
+        }
+    </ul>
+</div>
+
+@code
+{
+    [Parameter]
+    public List<RegimentFilter> Regiments { get; set; } = new();
+
+    [Parameter]
+    public EventCallback<int> ToggleRegiment { get; set; }
+
+    private async Task UpdateRegiment(int regimentId)
+    {
+        if (ToggleRegiment.HasDelegate)
+        {
+            await ToggleRegiment.InvokeAsync(regimentId);
+        }
+    }
+}

--- a/src/RollOfHonour.Web/Pages/Search/Results.razor
+++ b/src/RollOfHonour.Web/Pages/Search/Results.razor
@@ -141,7 +141,7 @@
                             </div>
                         </div>
 
-                        <button title="Look at this record" type="button" @onclick="FilterSearch" class="button primary"><i
+                        <button title="Look at this record" type="button" disabled="@_isLoading" @onclick="FilterSearch" class="button primary"><i
                                 class="fal fa-glasses" aria-hidden="true"></i> Filter Search
                         </button>
 
@@ -265,9 +265,11 @@
 
     private async Task FilterSearch()
     {
+        _isLoading = true;
         PageIndex = 1;
         _ = await JSRuntime.InvokeAsync<bool>("scrollToElementId", "results-jump-to");
         await QueryPeople(true, PageIndex, 20);
+        _isLoading = false;
     }
 
     private void ToggleRegiment(int regimentId)

--- a/src/RollOfHonour.Web/Pages/Search/Results.razor
+++ b/src/RollOfHonour.Web/Pages/Search/Results.razor
@@ -37,7 +37,7 @@
             </nav>
         </div>
 
-        @if (HasResults)
+        @if (HasResults || _isLoading)
         {
             <div class="columns is-multiline">
 
@@ -49,7 +49,12 @@
                             you need
                             to and the results will update for you.</p>
                     </div>
-                    <ResultsListComponent PersonSearchResults="@PersonSearchResults" MemorialSearchResults="@MemorialSearchResults" ChangePage="@ChangePage"/>
+                    <ResultsListComponent 
+                        @bind-PersonSearchResults="PersonSearchResults" 
+                        @bind-MemorialSearchResults="MemorialSearchResults" 
+                        @bind-PageIndex="PageIndex" 
+                        ChangePage="@ChangePage"
+                    />
                 </div>
                 <div class="column is-full-tablet is-4-desktop is-4-widescreen is-4-fullhd">
                     <aside class="sidebar" id="jumpto-filters">
@@ -188,6 +193,7 @@
     private int _dateOfDeathFilter { get; set; } = 1900;
     private int _dateOfBirthFilter { get; set; } = 1900;
     private List<RegimentFilter> _regimentFilters { get; set; } = new();
+    private bool _isLoading = true;
     public PaginatedList<Core.Models.Memorial> MemorialSearchResults = new();
     public PaginatedList<Core.Models.Person> PersonSearchResults = new();
     public bool HasResults => (MemorialSearchResults.Count() > 0 || PersonSearchResults.Count() > 0);
@@ -222,6 +228,7 @@
 
             MemorialSearchResults = results.Value;
         }
+        _isLoading = false;
     }
 
     protected override void OnParametersSet()
@@ -258,7 +265,9 @@
 
     private async Task FilterSearch()
     {
-        await QueryPeople(true, 1, 20);
+        PageIndex = 1;
+        _ = await JSRuntime.InvokeAsync<bool>("scrollToElementId", "results-jump-to");
+        await QueryPeople(true, PageIndex, 20);
     }
 
     private void ToggleRegiment(int regimentId)
@@ -275,9 +284,11 @@
 
     private async Task ChangePage(int page)
     {
+        _isLoading = true;
         PageIndex = page;
-        await QueryPeople(true, PageIndex, 20);
         _ = await JSRuntime.InvokeAsync<bool>("scrollToElementId", "results-jump-to");
+        await QueryPeople(true, PageIndex, 20);
+        _isLoading = false;
     }
 
     private PersonQuery BuildPersonQuery()

--- a/src/RollOfHonour.Web/Pages/Search/Results.razor
+++ b/src/RollOfHonour.Web/Pages/Search/Results.razor
@@ -40,6 +40,7 @@
         @if (HasResults)
         {
             <div class="columns is-multiline">
+
                 <div id="results-jump-to" class="column is-full-tablet is-8-desktop is-8-widescreen is-8-fullhd">
 
                     <div class="text-block">
@@ -48,26 +49,10 @@
                             you need
                             to and the results will update for you.</p>
                     </div>
-
-                    <div class="mobile-search-block">
-                        <a href="#jumpto-filters" title="Change or filter these results"><i
-                                class="fal fa-sort-size-down"></i> Change
-                            or filter these search results?</a>
-                    </div>
-                    @if (PersonSearchResults.Any())
-                    {
-                        <PersonResults People=@PersonSearchResults />
-                        <PagerComponent CurrentPage="@PageIndex" PageCount="@PersonSearchResults.TotalPages"
-                    ChangePage="@ChangePage"></PagerComponent>
-                    }
-                    else if (MemorialSearchResults.Any())
-                    {
-                        <MemorialResults Memorials=@MemorialSearchResults />
-                    }
+                    <ResultsListComponent PersonSearchResults="@PersonSearchResults" MemorialSearchResults="@MemorialSearchResults" ChangePage="@ChangePage"/>
                 </div>
                 <div class="column is-full-tablet is-4-desktop is-4-widescreen is-4-fullhd">
                     <aside class="sidebar" id="jumpto-filters">
-
                         <div class="search-filter-block">
                             <div class="form-toggle-block">
                                 <span class="toggle-label">
@@ -165,7 +150,6 @@
         }
         else
         {
-
             <div class="form-block with-margin-bottom with-margin-top" data-aos="fade-up">
                 <div class="form-row">
                     <h1>Your query returned no results.</h1>

--- a/src/RollOfHonour.Web/Pages/Search/Results.razor
+++ b/src/RollOfHonour.Web/Pages/Search/Results.razor
@@ -2,6 +2,7 @@
 
 @inject RollOfHonour.Core.Search.ISuperSearchService _searchService;
 @inject IJSRuntime JSRuntime;
+@inject NavigationManager navManager;
 @using Ardalis.Result;
 @using RollOfHonour.Core.Enums;
 @using RollOfHonour.Core.Models;
@@ -164,7 +165,15 @@
         }
         else
         {
-            <h1>Your query returned no results.</h1>
+
+            <div class="form-block with-margin-bottom with-margin-top" data-aos="fade-up">
+                <div class="form-row">
+                    <h1>Your query returned no results.</h1>
+                    <button type="button" @onclick="ReturnToSearch" class="submit-button centered" form="search-all"><i
+                            class="fal fa-file-search"></i> Search our
+                        records</button>
+                </div>
+            </div>
         }
     </div>
 </section>
@@ -270,14 +279,14 @@
 
     private void ToggleRegiment(int regimentId)
     {
-       if (_regimentIds.Contains(regimentId))
-       {
+        if (_regimentIds.Contains(regimentId))
+        {
             _regimentIds.Remove(regimentId);
-       }
-       else
-       {
+        }
+        else
+        {
             _regimentIds.Add(regimentId);
-       }
+        }
     }
 
     private async Task ChangePage(int page)
@@ -316,5 +325,10 @@
         _selectedQueryType = (QueryType)SelectedQueryType;
         _selectedPersonType = (PersonType)SelectedPersonType;
         _selectedWar = (War)SelectedWar;
+    }
+
+    private void ReturnToSearch()
+    {
+        navManager.NavigateTo($"/Search", false);
     }
 }

--- a/src/RollOfHonour.Web/Pages/Search/Results.razor
+++ b/src/RollOfHonour.Web/Pages/Search/Results.razor
@@ -162,6 +162,10 @@
                 </div>
             </div>
         }
+        else
+        {
+            <h1>Your query returned no results.</h1>
+        }
     </div>
 </section>
 
@@ -215,13 +219,11 @@
 
             if (results.IsSuccess is not true)
             {
-                // There were no results found so return
                 return;
             }
 
             if (!results.Value.Any())
             {
-                // There were no results found so return
                 return;
             }
 

--- a/src/RollOfHonour.Web/Pages/Search/Results.razor
+++ b/src/RollOfHonour.Web/Pages/Search/Results.razor
@@ -52,7 +52,8 @@
                     <ResultsListComponent 
                         @bind-PersonSearchResults="PersonSearchResults" 
                         @bind-MemorialSearchResults="MemorialSearchResults" 
-                        @bind-PageIndex="PageIndex" 
+                        @bind-PageIndex="PageIndex"
+                        @bind-IsLoading="_isLoading" 
                         ChangePage="@ChangePage"
                     />
                 </div>
@@ -194,6 +195,7 @@
     private int _dateOfBirthFilter { get; set; } = 1900;
     private List<RegimentFilter> _regimentFilters { get; set; } = new();
     private bool _isLoading = true;
+    private const int _pageSize = 10;
     public PaginatedList<Core.Models.Memorial> MemorialSearchResults = new();
     public PaginatedList<Core.Models.Person> PersonSearchResults = new();
     public bool HasResults => (MemorialSearchResults.Count() > 0 || PersonSearchResults.Count() > 0);
@@ -206,7 +208,7 @@
 
         if (_selectedQueryType == QueryType.Person)
         {
-            await QueryPeople(false, PageIndex, 20);
+            await QueryPeople(false, PageIndex);
             _regimentFilters = await _searchService.GetRegimentFiltersForSearch(BuildPersonQuery());
         }
 
@@ -214,7 +216,7 @@
         {
             var searchQuery = BuildMemorialQuery();
 
-            Result<PaginatedList<Core.Models.Memorial>> results = await _searchService.MemorialSearch(searchQuery, PageIndex, 20);
+            Result<PaginatedList<Core.Models.Memorial>> results = await _searchService.MemorialSearch(searchQuery, PageIndex, _pageSize);
 
             if (results.IsSuccess is not true)
             {
@@ -236,13 +238,14 @@
         SetSearchParamsFromQuery();
     }
 
-    private async Task QueryPeople(bool stateChangeNeeded, int pageIndex, int pageSize)
+    private async Task QueryPeople(bool stateChangeNeeded, int pageIndex)
     {
+        PersonSearchResults = new();
         if (_selectedQueryType == QueryType.Person)
         {
             var query = BuildPersonQuery();
             var filters = new Filters(_dateOfDeathFilter, _dateOfBirthFilter, _selectedPersonType, _regimentIds);
-            Result<PaginatedList<Core.Models.Person>> results = await _searchService.PersonSearch(query, filters, pageIndex, 5);
+            Result<PaginatedList<Core.Models.Person>> results = await _searchService.PersonSearch(query, filters, pageIndex, _pageSize);
 
             if (results.IsSuccess is not true)
             {
@@ -268,7 +271,7 @@
         _isLoading = true;
         PageIndex = 1;
         _ = await JSRuntime.InvokeAsync<bool>("scrollToElementId", "results-jump-to");
-        await QueryPeople(true, PageIndex, 20);
+        await QueryPeople(true, PageIndex);
         _isLoading = false;
     }
 
@@ -289,7 +292,7 @@
         _isLoading = true;
         PageIndex = page;
         _ = await JSRuntime.InvokeAsync<bool>("scrollToElementId", "results-jump-to");
-        await QueryPeople(true, PageIndex, 20);
+        await QueryPeople(true, PageIndex);
         _isLoading = false;
     }
 

--- a/src/RollOfHonour.Web/Pages/Search/Results.razor
+++ b/src/RollOfHonour.Web/Pages/Search/Results.razor
@@ -56,7 +56,8 @@
                     @if (PersonSearchResults.Any())
                     {
                         <PersonResults People=@PersonSearchResults />
-                        <PagerComponent CurrentPage="@PageIndex" PageCount="@PersonSearchResults.TotalPages" ChangePage="@ChangePage"></PagerComponent>
+                        <PagerComponent CurrentPage="@PageIndex" PageCount="@PersonSearchResults.TotalPages"
+                    ChangePage="@ChangePage"></PagerComponent>
                     }
                     else if (MemorialSearchResults.Any())
                     {
@@ -91,97 +92,26 @@
                                 </ul>
                             </div>
                         </div>
-
                         <div class="search-filter-block">
                             <span class="filter-label">
-                                Search between a specific period
+                                Filter by regiment
                             </span>
-                            <ul class="button-list">
-                                <li>
-                                    <div class="button_checkbox">
-                                        <input type="checkbox" id="battalion_1">
-                                        <label for="battalion_1">101st Airborne Division</label>
-                                    </div>
-                                </li>
-                                <li>
-                                    <div class="button_checkbox">
-                                        <input type="checkbox" id="battalion_2">
-                                        <label for="battalion_2">1st Armored Division</label>
-                                    </div>
-                                </li>
-                                <li>
-                                    <div class="button_checkbox">
-                                        <input type="checkbox" id="battalion_3">
-                                        <label for="battalion_3">1st Infantry Division</label>
-                                    </div>
-                                </li>
-                                <li>
-                                    <div class="button_checkbox">
-                                        <input type="checkbox" id="battalion_4">
-                                        <label for="battalion_4">2nd Infantry Division</label>
-                                    </div>
-                                </li>
-                                <li>
-                                    <div class="button_checkbox">
-                                        <input type="checkbox" id="battalion_5">
-                                        <label for="battalion_5">3rd Infantry Division</label>
-                                    </div>
-                                </li>
-                                <li>
-                                    <div class="button_checkbox">
-                                        <input type="checkbox" id="battalion_6">
-                                        <label for="battalion_6">4th Armored Division</label>
-                                    </div>
-                                </li>
-                                <li>
-                                    <div class="button_checkbox">
-                                        <input type="checkbox" id="battalion_7">
-                                        <label for="battalion_7">5th Infantry Division</label>
-                                    </div>
-                                </li>
-                                <li>
-                                    <div class="button_checkbox">
-                                        <input type="checkbox" id="battalion_8">
-                                        <label for="battalion_8">7th Armored Division</label>
-                                    </div>
-                                </li>
-                                <li>
-                                    <div class="button_checkbox">
-                                        <input type="checkbox" id="battalion_9">
-                                        <label for="battalion_9">7th Infantry Division</label>
-                                    </div>
-                                </li>
-                                <li>
-                                    <div class="button_checkbox">
-                                        <input type="checkbox" id="battalion_10">
-                                        <label for="battalion_10">10th Mountain Division</label>
-                                    </div>
-                                </li>
-                                <li>
-                                    <div class="button_checkbox">
-                                        <input type="checkbox" id="battalion_11">
-                                        <label for="battalion_11">11th Armored Division</label>
-                                    </div>
-                                </li>
-                                <li>
-                                    <div class="button_checkbox">
-                                        <input type="checkbox" id="battalion_12">
-                                        <label for="battalion_12">12th Armored Division</label>
-                                    </div>
-                                </li>
-                                <li>
-                                    <div class="button_checkbox">
-                                        <input type="checkbox" id="battalion_13">
-                                        <label for="battalion_13">17th Airborne Division</label>
-                                    </div>
-                                </li>
+                            <ul class="button-list"> 
+                                @foreach (var regiment in _regimentFilters)
+                                {
+                                    <li>
+                                        <div class="button_checkbox">
+                                            <input type="checkbox" @onchange="(e => ToggleRegiment(regiment.RegimentId))" id="@regiment.Regiment">
+                                            <label for="@regiment.Regiment">@regiment.Regiment</label>
+                                        </div>
+                                    </li>
+                                }
                             </ul>
                         </div>
-
                         <div class="search-filter-block">
                             <div class="date-range-block">
                                 <span class="filter-label">
-                                    Search between a specific period
+                                    Filter between a specific period
                                 </span>
 
                                 <ul>
@@ -233,7 +163,8 @@
                         </div>
 
                         <button title="Look at this record" type="button" @onclick="FilterSearch" class="button primary"><i
-                                class="fal fa-glasses" aria-hidden="true"></i> Filter Search </button>
+                                class="fal fa-glasses" aria-hidden="true"></i> Filter Search
+                        </button>
 
                         <a href="#jumpto-results" class="button primary mobile-results-button"
                             title="Go back to search results">
@@ -268,10 +199,10 @@
     private QueryType _selectedQueryType { get; set; } = QueryType.Person;
     private War _selectedWar { get; set; } = (int)War.WW1;
     private PersonType _selectedPersonType { get; set; } = PersonType.Military;
+    private HashSet<int> _regimentIds { get; set; } = new();
     private int _dateOfDeathFilter { get; set; } = 1900;
-
     private int _dateOfBirthFilter { get; set; } = 1900;
-
+    private List<RegimentFilter> _regimentFilters { get; set; } = new();
     public PaginatedList<Core.Models.Memorial> MemorialSearchResults = new();
     public PaginatedList<Core.Models.Person> PersonSearchResults = new();
     public bool HasResults => (MemorialSearchResults.Count() > 0 || PersonSearchResults.Count() > 0);
@@ -285,6 +216,13 @@
         if (_selectedQueryType == QueryType.Person)
         {
             await QueryPeople(false, PageIndex, 20);
+
+            _regimentFilters = PersonSearchResults
+            .Where(p => p.RegimentId != null)
+            // Will never be null but coalesced to prevent warning
+            .Select(p => new RegimentFilter(p.RegimentId ?? 0, p.Regiment))
+            .DistinctBy(r => r.RegimentId)
+            .ToList();
         }
 
         else if (_selectedQueryType == QueryType.Memorial)
@@ -295,19 +233,21 @@
 
             if (results.IsSuccess is not true)
             {
-                // Do something
+                // There were no results found so return
+                return;
             }
 
             if (!results.Value.Any())
             {
-                // Do something
+                // There were no results found so return
+                return;
             }
 
             MemorialSearchResults = results.Value;
         }
     }
 
-    protected override async Task OnParametersSetAsync()
+    protected override void OnParametersSet()
     {
         SetSearchParamsFromQuery();
     }
@@ -317,19 +257,19 @@
         if (_selectedQueryType == QueryType.Person)
         {
             var query = BuildPersonQuery();
-            // TODO: Implement regiment filters
-            var filters = new Filters(_dateOfDeathFilter, _dateOfBirthFilter, _selectedPersonType, new());
-            Result<PaginatedList<Core.Models.Person>> results = await _searchService.PersonSearch(query, filters, pageIndex, 20);
+            var filters = new Filters(_dateOfDeathFilter, _dateOfBirthFilter, _selectedPersonType, _regimentIds);
+            Result<PaginatedList<Core.Models.Person>> results = await _searchService.PersonSearch(query, filters, pageIndex, 5);
 
             if (results.IsSuccess is not true)
             {
-                // viewbag error probably
+                return;
             }
 
             if (!results.Value.Any())
             {
-                // I'm not sure this can happen
+                return;
             }
+
 
             PersonSearchResults = results.Value;
             if (stateChangeNeeded)
@@ -342,6 +282,18 @@
     private async Task FilterSearch()
     {
         await QueryPeople(true, 1, 20);
+    }
+
+    private void ToggleRegiment(int regimentId)
+    {
+       if (_regimentIds.Contains(regimentId))
+       {
+            _regimentIds.Remove(regimentId);
+       }
+       else
+       {
+            _regimentIds.Add(regimentId);
+       }
     }
 
     private async Task ChangePage(int page)

--- a/src/RollOfHonour.Web/Pages/Search/Results.razor
+++ b/src/RollOfHonour.Web/Pages/Search/Results.razor
@@ -216,13 +216,7 @@
         if (_selectedQueryType == QueryType.Person)
         {
             await QueryPeople(false, PageIndex, 20);
-
-            _regimentFilters = PersonSearchResults
-            .Where(p => p.RegimentId != null)
-            // Will never be null but coalesced to prevent warning
-            .Select(p => new RegimentFilter(p.RegimentId ?? 0, p.Regiment))
-            .DistinctBy(r => r.RegimentId)
-            .ToList();
+            _regimentFilters = await _searchService.GetRegimentFiltersForSearch(BuildPersonQuery());
         }
 
         else if (_selectedQueryType == QueryType.Memorial)

--- a/src/RollOfHonour.Web/Pages/Search/Results.razor
+++ b/src/RollOfHonour.Web/Pages/Search/Results.razor
@@ -92,22 +92,10 @@
                                 </ul>
                             </div>
                         </div>
-                        <div class="search-filter-block">
-                            <span class="filter-label">
-                                Filter by regiment
-                            </span>
-                            <ul class="button-list"> 
-                                @foreach (var regiment in _regimentFilters)
-                                {
-                                    <li>
-                                        <div class="button_checkbox">
-                                            <input type="checkbox" @onchange="(e => ToggleRegiment(regiment.RegimentId))" id="@regiment.Regiment">
-                                            <label for="@regiment.Regiment">@regiment.Regiment</label>
-                                        </div>
-                                    </li>
-                                }
-                            </ul>
-                        </div>
+                        @if (_regimentFilters.Any())
+                        {
+                            <RegimentFilters ToggleRegiment="ToggleRegiment" Regiments="_regimentFilters" />
+                        }
                         <div class="search-filter-block">
                             <div class="date-range-block">
                                 <span class="filter-label">

--- a/src/RollOfHonour.Web/Pages/Search/SearchComponent.razor
+++ b/src/RollOfHonour.Web/Pages/Search/SearchComponent.razor
@@ -14,7 +14,7 @@
 
 <div class="search-block" style="width: 100%; margin-bottom: 5%;">
     <div class="form-block" data-aos="fade-up">
-        <form id="search-all">
+        <form id="search-all" action="javascript:void(0);" >
             <div class="columns is-multiline">
                 <div class="column is-12-tablet is-12-desktop is-6-widescreen is-8-fullhd">
                     <div class="form-row">
@@ -241,7 +241,7 @@
             <div class="columns">
                 <div class="column is-full">
                     <div class="form-row">
-                        <button type="button" value="Search" @onclick="SearchRollOfHonour"
+                        <button type="submit" value="Search" @onclick="SearchRollOfHonour"
                             class="submit-button centered"><i class="fal fa-file-search"></i> Search our
                             records</button>
                     </div>
@@ -257,7 +257,7 @@
     private PersonType _selectedPersonType = PersonType.Military;
     private QueryType _selectedQueryType = QueryType.Person;
 
-    private async Task SearchRollOfHonour()
+    private void SearchRollOfHonour()
     {
         navManager.NavigateTo($"/Results?s={searchTerm}&w={(int)_selectedWar}&pt={(int)_selectedPersonType}&qt={(int)_selectedQueryType}");
     }

--- a/src/RollOfHonour.Web/Pages/Shared/Components/BasicSearchComponent.razor
+++ b/src/RollOfHonour.Web/Pages/Shared/Components/BasicSearchComponent.razor
@@ -1,7 +1,7 @@
 @inject NavigationManager navManager;
 
 <div class="form-block with-margin-bottom with-margin-top" data-aos="fade-up">
-    <form action="#search-controller" method="post" id="search-all">
+    <form id="search-all" action="javascript:void(0);" >
         <div class="form-row">
             <label for="searchquery" id="Query-ariaLabel">Begin your search by entering a name
                 below:</label>
@@ -9,8 +9,7 @@
                 title="Enter your search query here..." placeholder="e.g. Ken Ashford" />
         </div>
         <div class="form-row">
-            
-            <button type="button" @onclick="SearchRollOfHonour" class="submit-button" form="search-all"><i class="fal fa-file-search"></i> Search our
+            <button type="submit" @onclick="SearchRollOfHonour" class="submit-button"><i class="fal fa-file-search"></i> Search our
                 records</button>
         </div>
     </form>

--- a/src/RollOfHonour.Web/Pages/Shared/Components/PagerComponent.razor
+++ b/src/RollOfHonour.Web/Pages/Shared/Components/PagerComponent.razor
@@ -38,7 +38,7 @@
         [Parameter] 
         public EventCallback<int> ChangePage { get; set; }
 
-        protected override async Task OnInitializedAsync()
+        protected override void OnInitialized()
         {
             SetPageRange();
         }
@@ -69,6 +69,7 @@
             if (PageCount < 9)
             {
                 this.PageRange = Enumerable.Range(1, PageCount).ToArray();
+                return;
             }
 
             if (CurrentPage == 1)

--- a/src/RollOfHonour.Web/Pages/Shared/Components/PagerComponent.razor
+++ b/src/RollOfHonour.Web/Pages/Shared/Components/PagerComponent.razor
@@ -34,11 +34,16 @@
     [Parameter]
     public int CurrentPage { get; set; }
     [Parameter]
-    public int PageCount { get; set; }
-    [Parameter]
     public EventCallback<int> CurrentPageChanged { get; set; }
     [Parameter]
+    public int PageCount { get; set; }
+    [Parameter]
     public EventCallback<int> ChangePage { get; set; }
+
+    [Parameter]
+    public bool IsLoading { get; set; } = true;
+    [Parameter]
+    public EventCallback<bool> IsLoadingChanged { get; set; }
 
     protected override void OnInitialized()
     {
@@ -52,7 +57,7 @@
 
     private async Task UpdatePage(int page)
     {
-        if (ChangePage.HasDelegate)
+        if (ChangePage.HasDelegate && !IsLoading)
         {
             await ChangePage.InvokeAsync(page);
         }
@@ -68,7 +73,7 @@
             return;
         }
 
-        if (PageCount < 9)
+        if (PageCount <= 9)
         {
             this.PageRange = Enumerable.Range(1, PageCount).ToArray();
             return;

--- a/src/RollOfHonour.Web/Pages/Shared/Components/PagerComponent.razor
+++ b/src/RollOfHonour.Web/Pages/Shared/Components/PagerComponent.razor
@@ -2,11 +2,11 @@
     <ul>
         @if (HasPreviousPage)
         {
-        <li>
-            <a role="button" @onclick="@(e => UpdatePage(CurrentPage - 1))">
-                <i class="fa-light fa-chevron-left"></i>
-            </a>
-        </li>
+            <li>
+                <a role="button" @onclick="@(e => UpdatePage(CurrentPage - 1))">
+                    <i class="fa-light fa-chevron-left"></i>
+                </a>
+            </li>
         }
         @foreach (var pageNum in PageRange)
         {
@@ -17,82 +17,84 @@
         }
         @if (HasNextPage)
         {
-        <li>
-            <a @onclick="@(e => UpdatePage(CurrentPage + 1))">
-                <i class="fa-light fa-chevron-right"></i>
-            </a>
-        </li>
+            <li>
+                <a @onclick="@(e => UpdatePage(CurrentPage + 1))">
+                    <i class="fa-light fa-chevron-right"></i>
+                </a>
+            </li>
         }
     </ul>
 </div>
 
 @code {
-        public int[] PageRange { get; private set; } = new int[] { 0 };
-        public bool HasPreviousPage => CurrentPage > 1;
-        public bool HasNextPage => CurrentPage < PageCount;
+    public int[] PageRange { get; private set; } = new int[] { 0 };
+    public bool HasPreviousPage => CurrentPage > 1;
+    public bool HasNextPage => CurrentPage < PageCount;
 
-        [Parameter]
-        public int CurrentPage { get; set; }
-        [Parameter]
-        public int PageCount { get; set; }
-        [Parameter] 
-        public EventCallback<int> ChangePage { get; set; }
+    [Parameter]
+    public int CurrentPage { get; set; }
+    [Parameter]
+    public int PageCount { get; set; }
+    [Parameter]
+    public EventCallback<int> CurrentPageChanged { get; set; }
+    [Parameter]
+    public EventCallback<int> ChangePage { get; set; }
 
-        protected override void OnInitialized()
+    protected override void OnInitialized()
+    {
+        SetPageRange();
+    }
+
+    protected override void OnParametersSet()
+    {
+        SetPageRange();
+    }
+
+    private async Task UpdatePage(int page)
+    {
+        if (ChangePage.HasDelegate)
         {
-            SetPageRange();
+            await ChangePage.InvokeAsync(page);
         }
 
-        protected override void OnParametersSet()
+        CurrentPage = page;
+    }
+
+    private void SetPageRange()
+    {
+        if (PageCount == 1)
         {
-            SetPageRange();
+            this.PageRange = new int[] { 1 };
+            return;
         }
 
-        private async Task UpdatePage(int page)
+        if (PageCount < 9)
         {
-            if (ChangePage.HasDelegate)
-            {
-                await ChangePage.InvokeAsync(page);
-            }
-
-            CurrentPage = page;
+            this.PageRange = Enumerable.Range(1, PageCount).ToArray();
+            return;
         }
 
-        private void SetPageRange()
+        if (CurrentPage == 1)
         {
-            if (PageCount == 1)
-            {
-                this.PageRange = new int[] { 1 };
-                return;
-            }
-
-            if (PageCount < 9)
-            {
-                this.PageRange = Enumerable.Range(1, PageCount).ToArray();
-                return;
-            }
-
-            if (CurrentPage == 1)
-            {
-                this.PageRange = Enumerable.Range(1, 9).Append(PageCount).ToArray();
-                return;
-            }
-
-            int minRange = Math.Max(1, CurrentPage - 4);
-            int maxRange = Math.Min(PageCount, CurrentPage + 5);
-            if (minRange <= 1)
-            {
-                this.PageRange = Enumerable.Range(1, 9).Append(PageCount).ToArray();
-                return;
-            }
-
-            var count = (maxRange - minRange) + 1;
-            if (maxRange == PageCount)
-            {
-                this.PageRange = Enumerable.Range(minRange, count).Prepend(1).ToArray();
-                return;
-            }
-
-            this.PageRange = Enumerable.Range(minRange, count).Prepend(1).Append(PageCount).ToArray();
+            this.PageRange = Enumerable.Range(1, 9).Append(PageCount).ToArray();
+            return;
         }
+
+        int minRange = Math.Max(1, CurrentPage - 4);
+        int maxRange = Math.Min(PageCount, CurrentPage + 5);
+        if (minRange <= 1)
+        {
+            this.PageRange = Enumerable.Range(1, 9).Append(PageCount).ToArray();
+            return;
+        }
+
+        var count = (maxRange - minRange) + 1;
+        if (maxRange == PageCount)
+        {
+            this.PageRange = Enumerable.Range(minRange, count).Prepend(1).ToArray();
+            return;
+        }
+
+        this.PageRange = Enumerable.Range(minRange, count).Prepend(1).Append(PageCount).ToArray();
+    }
 }

--- a/src/RollOfHonour.Web/Pages/Shared/Components/ResultsListComponent.razor
+++ b/src/RollOfHonour.Web/Pages/Shared/Components/ResultsListComponent.razor
@@ -7,29 +7,38 @@
 @if (PersonSearchResults.Any())
 {
     <PersonResults People=@PersonSearchResults />
-    <PagerComponent CurrentPage="@PageIndex" PageCount="@PersonSearchResults.TotalPages" ChangePage="@UpdatePage">
+    <PagerComponent @bind-CurrentPage="PageIndex" PageCount="@PersonSearchResults.TotalPages" ChangePage="@UpdatePage">
     </PagerComponent>
 }
 else if (MemorialSearchResults.Any())
 {
     <MemorialResults Memorials=@MemorialSearchResults />
 }
+else
+{
+    <i class="fas fa-spinner fa-pulse"></i>
+}
 
 @code
 {
     [Parameter]
-    public PaginatedList<Core.Models.Memorial> MemorialSearchResults { get; set; } = new();
+    public PaginatedList<Memorial> MemorialSearchResults { get; set; } = new();
     [Parameter]
-    public PaginatedList<Core.Models.Person> PersonSearchResults { get; set; } = new();
+    public PaginatedList<Person> PersonSearchResults { get; set; } = new();
     [Parameter]
     public int PageIndex { get; set; } = 1;
-
+    [Parameter]
+    public EventCallback<PaginatedList<Person>> PersonSearchResultsChanged { get; set; }  
+    [Parameter]
+    public EventCallback<PaginatedList<Memorial>> MemorialSearchResultsChanged { get; set; }  
+    [Parameter]
+    public EventCallback<int> PageIndexChanged { get; set; }    
     [Parameter]
     public EventCallback<int> ChangePage { get; set; }
 
     private async Task UpdatePage(int page)
     {
-        if(ChangePage.HasDelegate)
+        if (ChangePage.HasDelegate)
         {
             await ChangePage.InvokeAsync(page);
         }

--- a/src/RollOfHonour.Web/Pages/Shared/Components/ResultsListComponent.razor
+++ b/src/RollOfHonour.Web/Pages/Shared/Components/ResultsListComponent.razor
@@ -7,7 +7,7 @@
 @if (PersonSearchResults.Any())
 {
     <PersonResults People=@PersonSearchResults />
-    <PagerComponent @bind-CurrentPage="PageIndex" PageCount="@PersonSearchResults.TotalPages" ChangePage="@UpdatePage">
+    <PagerComponent @bind-CurrentPage="PageIndex" @bind-IsLoading="IsLoading" PageCount="@PersonSearchResults.TotalPages" ChangePage="@UpdatePage">
     </PagerComponent>
 }
 else if (MemorialSearchResults.Any())
@@ -26,15 +26,19 @@ else
     [Parameter]
     public PaginatedList<Person> PersonSearchResults { get; set; } = new();
     [Parameter]
+    public EventCallback<PaginatedList<Person>> PersonSearchResultsChanged { get; set; }
+    [Parameter]
+    public EventCallback<PaginatedList<Memorial>> MemorialSearchResultsChanged { get; set; }
+    [Parameter]
     public int PageIndex { get; set; } = 1;
     [Parameter]
-    public EventCallback<PaginatedList<Person>> PersonSearchResultsChanged { get; set; }  
-    [Parameter]
-    public EventCallback<PaginatedList<Memorial>> MemorialSearchResultsChanged { get; set; }  
-    [Parameter]
-    public EventCallback<int> PageIndexChanged { get; set; }    
+    public EventCallback<int> PageIndexChanged { get; set; }
     [Parameter]
     public EventCallback<int> ChangePage { get; set; }
+    [Parameter]
+    public bool IsLoading { get; set; } = true;
+    [Parameter]
+    public EventCallback<bool> IsLoadingChanged { get; set; }
 
     private async Task UpdatePage(int page)
     {

--- a/src/RollOfHonour.Web/Pages/Shared/Components/ResultsListComponent.razor
+++ b/src/RollOfHonour.Web/Pages/Shared/Components/ResultsListComponent.razor
@@ -1,0 +1,37 @@
+@using RollOfHonour.Core.Models;
+
+<div class="mobile-search-block">
+    <a href="#jumpto-filters" title="Change or filter these results"><i class="fal fa-sort-size-down"></i> Change
+        or filter these search results?</a>
+</div>
+@if (PersonSearchResults.Any())
+{
+    <PersonResults People=@PersonSearchResults />
+    <PagerComponent CurrentPage="@PageIndex" PageCount="@PersonSearchResults.TotalPages" ChangePage="@UpdatePage">
+    </PagerComponent>
+}
+else if (MemorialSearchResults.Any())
+{
+    <MemorialResults Memorials=@MemorialSearchResults />
+}
+
+@code
+{
+    [Parameter]
+    public PaginatedList<Core.Models.Memorial> MemorialSearchResults { get; set; } = new();
+    [Parameter]
+    public PaginatedList<Core.Models.Person> PersonSearchResults { get; set; } = new();
+    [Parameter]
+    public int PageIndex { get; set; } = 1;
+
+    [Parameter]
+    public EventCallback<int> ChangePage { get; set; }
+
+    private async Task UpdatePage(int page)
+    {
+        if(ChangePage.HasDelegate)
+        {
+            await ChangePage.InvokeAsync(page);
+        }
+    }
+}


### PR DESCRIPTION
Included in PR:
- [x] Populate all possible filter values on the search results object
- [x] Handle no results appropriately
- [x] Disable interactivity while searching
- [x] Show loading spinners when searching

Todo:
- [ ] Filter on wars
- [ ] On results objects, show placeholders if null values returned (results and memorials

Known issues:
- Loading spinner is very small
- Changing pages doesn't show spinner
- If you spam click pages while loading, it'll look like it changes, but does not.
- Regiment filters don't layout 100% evenly
