### PR TITLE
MainPhoto promotion, where one exists

### DIFF
--- a/src/RollOfHonour.Core/Models/Memorial.cs
+++ b/src/RollOfHonour.Core/Models/Memorial.cs
@@ -31,6 +31,11 @@ public class Memorial : IAggregateRoot
     {
         get
         {
+            if (MainPhotoId.HasValue)
+            {
+                return Photos.Single(p => p.Id == MainPhotoId);
+            }
+
             //Photo decision
             //If main photo null, then use the first of the other images (or a random one)
             if (MainPhotoId == null && Photos.Any())

--- a/src/RollOfHonour.Core/Models/Memorial.cs
+++ b/src/RollOfHonour.Core/Models/Memorial.cs
@@ -31,14 +31,14 @@ public class Memorial : IAggregateRoot
     {
         get
         {
-            if (MainPhotoId.HasValue)
+            if (MainPhotoId.HasValue && Photos.Exists(p => p.Id == MainPhotoId))
             {
                 return Photos.Single(p => p.Id == MainPhotoId);
             }
 
             //Photo decision
             //If main photo null, then use the first of the other images (or a random one)
-            if (MainPhotoId == null && Photos.Any())
+            if (Photos.Any())
             {
                 //Promote an image to MainPhoto
                 return Photos.First();

--- a/src/RollOfHonour.Core/Models/Person.cs
+++ b/src/RollOfHonour.Core/Models/Person.cs
@@ -15,7 +15,7 @@ public class Person
     public string LastName { get; set; } = string.Empty;
 
     public string Rank { get; set; } =
-      string.Empty; //TODO: This needs cleaning up - so many similar entries. Autopicker/Prompt perhaps
+        string.Empty; //TODO: This needs cleaning up - so many similar entries. Autopicker/Prompt perhaps
 
     public string ServiceNumber { get; set; } = string.Empty;
 
@@ -104,8 +104,8 @@ public class Person
     public int? MainPhotoId { get; private set; }
 
     public string Name => string.IsNullOrEmpty(FirstNames)
-      ? string.IsNullOrEmpty(Initials) ? $"{LastName}" : $"{Initials} {LastName}"
-      : $"{FirstNames} {LastName}";
+        ? string.IsNullOrEmpty(Initials) ? $"{LastName}" : $"{Initials} {LastName}"
+        : $"{FirstNames} {LastName}";
 
     public List<Decoration> Decorations { get; set; } = new List<Decoration>();
     public Dictionary<int, string> Memorials { get; set; } = new Dictionary<int, string>();
@@ -114,6 +114,11 @@ public class Person
     {
         get
         {
+            if (MainPhotoId.HasValue)
+            {
+                return Photos.Single(p => p.Id == MainPhotoId);
+            }
+
             //Photo decision
             //If main photo null, then use the first of the other images (or a random one)
             if (MainPhotoId == null && Photos.Any())

--- a/src/RollOfHonour.Core/Models/Person.cs
+++ b/src/RollOfHonour.Core/Models/Person.cs
@@ -114,14 +114,14 @@ public class Person
     {
         get
         {
-            if (MainPhotoId.HasValue)
+            if (MainPhotoId.HasValue && Photos.Exists(p => p.Id == MainPhotoId))
             {
                 return Photos.Single(p => p.Id == MainPhotoId);
             }
 
             //Photo decision
             //If main photo null, then use the first of the other images (or a random one)
-            if (MainPhotoId == null && Photos.Any())
+            if (Photos.Any())
             {
                 //Promote an image to MainPhoto
                 return Photos.First();


### PR DESCRIPTION
Previously where a main photo did not exist, promotion of another image from their photo was working.  This has now been rectified.